### PR TITLE
version avec rajout kotlin et tornado fx dans les dependances (1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,39 @@
   <artifactId>libmanager-v3</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
+    <properties>
+        <kotlin.version>1.3.61</kotlin.version>
+    </properties>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals> <goal>compile</goal> </goals>
+                        <configuration>
+                            <jvmTarget>1.8</jvmTarget>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -14,6 +45,28 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals> <goal>testCompile</goal> </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -51,6 +104,16 @@
     <name>libmanager-v3</name>
   <url>http://maven.apache.org</url>
   <dependencies>
+      <dependency>
+          <groupId>no.tornado</groupId>
+          <artifactId>tornadofx</artifactId>
+          <version>1.7.19</version>
+      </dependency>
+      <dependency>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+          <version>${kotlin.version}</version>
+      </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
@@ -159,4 +222,5 @@
           <version>3.9.2</version>
       </dependency>
   </dependencies>
+
 </project>


### PR DESCRIPTION
Modification du fichier pom.xml pour rajouter la librarie tornadoFX et kotlin. 
modification de l'orde d'execution dans la compilation techniquement c'est kotlin qui est compilé en premier du fait de sa vérification à la compilation et non a l'execution. 

Voir  <artifactId>maven-compiler-plugin</artifactId>